### PR TITLE
fix: 감정세부기록 페이지 UI debugging

### DIFF
--- a/src/components/log/EmotionSelectCard.tsx
+++ b/src/components/log/EmotionSelectCard.tsx
@@ -124,7 +124,9 @@ export const FeelingCard = ({
   };
 
   const handleFeelingNumberClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    setSelectedFeelingIntensity(Number(e.currentTarget.id));
+    if (selectedFeeling !== null) {
+      setSelectedFeelingIntensity(Number(e.currentTarget.id));
+    }
   };
 
   return (

--- a/src/components/log/EmotionSelectCard.tsx
+++ b/src/components/log/EmotionSelectCard.tsx
@@ -168,6 +168,9 @@ export const FeelingCard = ({
         <div className="flex gap-[.38rem]">
           {[20, 40, 60, 80, 100].map((intensity) => {
             const isSelected = selectedFeelingIntensity === intensity / 20;
+            const isNotInRange =
+              selectedFeelingIntensity &&
+              selectedFeelingIntensity < intensity / 20;
 
             return (
               <div
@@ -175,7 +178,9 @@ export const FeelingCard = ({
                 key={intensity}
                 className={`w-[3.882rem] h-[3.882rem] border rounded-[0.863rem] cursor-pointer`}
                 style={{
-                  backgroundColor: `var(--${color}-${intensity})`,
+                  backgroundColor: isNotInRange
+                    ? '#F7F7F7'
+                    : `var(--${color}-${intensity})`,
                   borderColor: `${
                     isSelected ? `var(--${color}-120)` : 'transparent'
                   }`,

--- a/src/components/modals/ConfirmModal.tsx
+++ b/src/components/modals/ConfirmModal.tsx
@@ -16,8 +16,8 @@ const ConfirmModal = ({
   onCancle,
 }: Props) => {
   return (
-    <div className="absolute top-0 left-[-10.3rem] w-screen h-full bg-[#0000004d] z-[10000]">
-      <div className="absolute top-[calc(50vh-17.7rem)] left-[calc(50vw-21.65rem)] bg-white px-[4.7rem] py-[3.25rem] rounded-[2rem] flex flex-col items-center">
+    <div className="fixed top-[5.81rem] left-0 w-screen h-full bg-[#0000004d] z-[10000]">
+      <div className="fixed top-2/4 translate-y-[-50%] left-2/4 translate-x-[-50%] bg-white px-[4.7rem] py-[3.25rem] rounded-[2rem] flex flex-col items-center">
         <span className="text-heading3 text-gray-9 flex flex-col items-center mb-[3.1rem]">
           {title}
         </span>

--- a/src/components/modals/ConfirmModal.tsx
+++ b/src/components/modals/ConfirmModal.tsx
@@ -1,0 +1,44 @@
+interface Props {
+  title: React.ReactNode;
+  content: React.ReactNode;
+  confirmText: string;
+  cancleText: string;
+  onConfirm: () => void;
+  onCancle: () => void;
+}
+
+const ConfirmModal = ({
+  title,
+  content,
+  confirmText,
+  cancleText,
+  onConfirm,
+  onCancle,
+}: Props) => {
+  return (
+    <div className="absolute top-0 left-[-10.3rem] w-screen h-full bg-[#0000004d] z-[10000]">
+      <div className="absolute top-[calc(50vh-17.7rem)] left-[calc(50vw-21.65rem)] bg-white px-[4.7rem] py-[3.25rem] rounded-[2rem] flex flex-col items-center">
+        <span className="text-heading3 text-gray-9 flex flex-col items-center mb-[3.1rem]">
+          {title}
+        </span>
+        <span className="text-body2 text-gray-9 flex flex-col items-center mb-[3.1rem]">
+          {content}
+        </span>
+        <button
+          className={`w-[33.9rem] h-[4.8rem] text-body1 rounded-[4.8rem] text-red-100 hover:bg-red-10`}
+          onClick={onConfirm}
+        >
+          {confirmText}
+        </button>
+        <button
+          className={`w-[33.9rem] h-[4.8rem] text-body1 rounded-[4.8rem] text-gray-5 hover:bg-gray-2`}
+          onClick={onCancle}
+        >
+          {cancleText}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmModal;

--- a/src/pages/clients/index.tsx
+++ b/src/pages/clients/index.tsx
@@ -10,6 +10,7 @@ import { IoMdPersonAdd } from 'react-icons/io';
 import { CiSearch } from 'react-icons/ci';
 import { TfiClose } from 'react-icons/tfi';
 import Alert from '@/components/Alert';
+import ConfirmModal from '@/components/modals/ConfirmModal';
 
 const ClientsPage = () => {
   const [clientsList, setClientsList] =
@@ -205,36 +206,24 @@ const ClientsPage = () => {
 
         {/* 내담자 삭제 모달 */}
         {isDeleteModalVisible && (
-          <div className="absolute top-0 left-[-10.3rem] w-screen h-full bg-[#0000004d] z-[10000]">
-            <div className="absolute top-[calc(50vh-17.7rem)] left-[calc(50vw-21.65rem)] bg-white px-[4.7rem] py-[3.25rem] rounded-[2rem] flex flex-col items-center">
-              <span className="text-heading3 text-gray-9 mb-[3.1rem]">
-                내담자 삭제
-              </span>
-              <span className="text-heading2 text-gray-9">
-                {selectedClient?.counseleeName}
-              </span>
-              <span className="text-body2 text-gray-9">
-                내담자에 대한 정보가 모두 사라집니다!
-              </span>
-              <span className="text-body2 text-gray-9 mb-[3.1rem]">
-                정말 삭제하시겠습니까?
-              </span>
-              <button
-                className={`w-[33.9rem] h-[4.8rem] text-body1 rounded-[4.8rem] text-red-100 hover:bg-red-10`}
-                onClick={() => {
-                  onDeleteClient(selectedClient?.counseleeId);
-                }}
-              >
-                네, 삭제하겠습니다.
-              </button>
-              <button
-                className={`w-[33.9rem] h-[4.8rem] text-body1 rounded-[4.8rem] text-gray-5 hover:bg-gray-2`}
-                onClick={() => setIsDeleteModalVisible(false)}
-              >
-                아니오, 삭제하지 않겠습니다.
-              </button>
-            </div>
-          </div>
+          <ConfirmModal
+            title="내담자 삭제"
+            content={
+              <>
+                <span className="text-heading2">
+                  {selectedClient?.counseleeName}
+                </span>
+                <div>내담자에 대한 정보가 모두 사라집니다!</div>
+                <div>정말 삭제하시겠습니까?</div>
+              </>
+            }
+            confirmText="네, 삭제하겠습니다."
+            cancleText="아니오, 삭제하지 않겠습니다."
+            onConfirm={() => {
+              onDeleteClient(selectedClient?.counseleeId);
+            }}
+            onCancle={() => setIsDeleteModalVisible(false)}
+          />
         )}
 
         {/* alert */}

--- a/src/pages/log/index.tsx
+++ b/src/pages/log/index.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 
 import { BsChevronDown, BsChevronUp } from 'react-icons/bs';
 
-
 import {
   EmotionAddCard,
   EmotionAddCardDisabled,
@@ -78,6 +77,8 @@ const RecordsCreatePage = () => {
       selectedMediumEmotion !== null
     ) {
       setCurrentProcess(2);
+      setSelectedFeeling(null);
+      setSelectedFeelingIntensity(0);
     }
   }, [selectedMediumEmotion]);
 


### PR DESCRIPTION
## 작업 내용

- [feat: ConfirmModal 별도 컴포넌트 분리](https://github.com/TherapEase-CEOS/TherapEase-FE/commit/2816a1ba4f40b7d74dd38f24d76c6a59a6b5cb78)
- [fix: selectedMediumEmotion 변동 시 feeling 선택 초기화](https://github.com/TherapEase-CEOS/TherapEase-FE/commit/0960c4a3320b9d06d01b306a11b515e89933d47f)
- [fix: feeling 선택시에만 intentsity 선택 가능하도록 수정](https://github.com/TherapEase-CEOS/TherapEase-FE/commit/07d2624110b79bac50cf3d4c063b8bd8ea5fa7b4)
- [fix: 선택되지 않은 selectedFeelingIntensity 색상 수정](https://github.com/TherapEase-CEOS/TherapEase-FE/commit/6afef579845ac2ab280d307e65722a257b2090d6)
- [fix: ConfirmModal position 수정](https://github.com/TherapEase-CEOS/TherapEase-FE/pull/37/commits/84a672f27f33aced99b1508790c79af1930ab250)

## 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 전달 사항

<!-- 전달 사항이 있다면 적어주세요 -->
